### PR TITLE
fix(package): don't use http namespace to avoid esModuleInterop issues

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import http from 'http';
+import { createServer, Server as httpServer } from 'http';
 import { Express } from 'express';
 import * as nodeFetch from 'node-fetch';
 import Server from './Server';
@@ -36,7 +36,7 @@ export {
  *   has 'exepect' methods on it.
  */
 export default function fetch(
-    server: http.Server,
+    server: httpServer,
     url: string | nodeFetch.Request,
     init?: nodeFetch.RequestInit
 ): Test {
@@ -60,12 +60,12 @@ export default function fetch(
  * @returns - a `fetch(url, options)` function, compatible with WHATWG
  *  fetch, but which returns `Test` objects.
  */
-export function makeFetch(target: http.Server | Express) {
+export function makeFetch(target: httpServer | Express) {
 
     // if we were given an express app
     const server = target && (target as Express).route
-        ? http.createServer(target as Express)
-        : (target as http.Server);
+        ? createServer(target as Express)
+        : (target as httpServer);
 
     if(!server || !server.listen || !server.address || !server.close) {
         throw new Error("Expected server");


### PR DESCRIPTION
When compiling typescript with a `tsconfig.json` that doesn't use `esModuleInterop` the definitions in this library will conflict. Changing these to named exports fixes this. Solution found [here](https://github.com/fridays/next-routes/pull/158).

```
/app # yarn tsc
node_modules/supertest-fetch/types/index.d.ts:3:8 - error TS1192: Module '"http"' has no default export.

3 import http from 'http';
         ~~~~

error An unexpected error occurred: "Command failed.
Exit code: 2
Command: sh
Arguments: -c tsc
".
```